### PR TITLE
"Fix" the project generator (espresso init)

### DIFF
--- a/core/commands/deploy.js
+++ b/core/commands/deploy.js
@@ -61,7 +61,8 @@ exports.run = function (options, positional) {
           'Your <config.json>["deploy"]['
           + JSON.stringify(target)
           + ']'
-          + (config[target] instanceof Object
+          + (config instanceof Object &&
+             config[target] instanceof Object
             ? '[' + JSON.stringify(config[target].method) + ']'
             : '')
           + ' is made of stupid!'

--- a/generator/project_generator.js
+++ b/generator/project_generator.js
@@ -225,8 +225,16 @@ var generate = exports.generate = function generate(options) {
 
       Util.pump(Fs.createReadStream(currentFile.path), writeStream, function (err) {
           if (err) {
-            throw err;
-          }
+            if (err.code === 'ENOENT') {
+              // TODO maybe we should check if dir(err.path) is a directory
+              //      we didn't create and only then skip this error.
+
+              // ignore files we cannot create due to missing directories:
+              // else we'd create them at "Output dirs" above.
+            } else {
+              throw err;
+            };
+          };
           copyProject(files);
         });
     }


### PR DESCRIPTION
Making The-M-Project a Git submodule triggered a bug in the project generator (espresso init) that caused an exception to be thrown when the source directory (i.e. frameworks/The-M-Projects) has more directories than the target directory (i.e. the generated directory) and thus source files get copied to non-existing directories.

The core problem is that the target directory structure is hard-coded in the project generator and thus already "knows" how The-M-Project's directory structure looks like.

This commit simply ignores any failed attempt to copy over a file and works "good enough".

In the (not so) long term we'd like to have more dynamic project generator, I guess... ^_^
