### PR TITLE
Compatibility patch for node-0.6

### DIFF
--- a/bin/espresso.js
+++ b/bin/espresso.js
@@ -6,8 +6,15 @@
  * @author pfleidi
  */
 
-var COMMAND_FOLDER = __dirname + '/../core/commands/';
-var cmdParser = require('../lib/commandparser').create(COMMAND_FOLDER, 'espresso');
+var fs = require('fs');
+var path = require('path');
+
+var espresso_root = path.dirname(path.dirname(fs.realpathSync(__filename)));
+
+var COMMAND_FOLDER = path.join(espresso_root, 'core', 'commands');
+var commandparser = require(path.join(espresso_root, 'lib', 'commandparser'));
+
+var cmdParser = commandparser.create(COMMAND_FOLDER + '/', 'espresso');
 var args;
 
 if (process.argv[0].slice(-4) == "node") {

--- a/core/app.js
+++ b/core/app.js
@@ -668,7 +668,14 @@ App.prototype.makeOutputFolder = function (callback) {
     that.makeOutputDir = function (path) {
       if (that._folderCounter >=1) {
         self._e_.fs.mkdir(path, 0777 ,function (err) {
-          if (err && err.errno !== 17) {throw err;}
+          if (err) {
+            if (err.code === 'EEXIST') {
+              // ok: directory already exists; that's what we want!
+            } else {
+              // this is the "old-and-underdocumented" behavior
+              if (err && err.errno !== 17) {throw err;}
+            };
+          };
           that._folderCounter--;
           that.makeOutputDir(path+ self._outP.shift());
         });


### PR DESCRIPTION
This commit uses a new version of wwwdude and an appropriate check of the error-code when creating the App's build directory.

Additionally this commit allows to symlink bin/espresso.js somewhere in your $PATH.
