### PR TITLE
Fixed issue when running on windows

### DIFF
--- a/bin/espresso.js
+++ b/bin/espresso.js
@@ -17,7 +17,7 @@ var commandparser = require(path.join(espresso_root, 'lib', 'commandparser'));
 var cmdParser = commandparser.create(COMMAND_FOLDER + '/', 'espresso');
 var args;
 
-if (process.argv[0].slice(-4) == "node") {
+if (process.argv[0].slice(-4) == "node" || process.argv[0].slice(-8) == "node.exe") {
   args = process.argv.slice(2);
 } else {
   args = process.argv.slice(1);


### PR DESCRIPTION
Hi,

I had a problem when running this on windows, the first argument was node.exe not node, so the command line arguments being passed were getting ignored.

Thanks,
Tom
