### PR TITLE
remove width=device-width for iPhone5

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -437,6 +437,17 @@ App.prototype.buildIndexHTML = function (callback, _frameworkNamesForIndexHtml, 
              , 'width=device-width'
              ].join(',')
   }));
+
+  _indexHtml.push(HTML('meta', {
+    name: 'viewport',
+    content: [ 'initial-scale=1.0'
+             , 'minimum-scale=1.0'
+             , 'maximum-scale=1.0'
+             , 'user-scalable=no'
+             ].join(','),
+    media: '(device-height: 568px)'
+  }));
+
   _indexHtml.push(HTML('title', {}, _displayName));
 
     _indexHtml.push(HTML('script', {


### PR DESCRIPTION
we need to remove width=device-width in viewport content to make webapp
(add to home screen) have full screen on iPhone 5.
